### PR TITLE
Add initial Express API service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.db*
+*.sqlite

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # codex-cool-webboard
-pure pastel color web board for user can participate (dev with node.js and SQLite database) with user management (feature : chat, tag, favorite)
+
+This project provides a simple API service for a pastel color themed web board. It is built with Node.js, Express and SQLite.
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm start
+```
+
+The API will be available on `http://localhost:3000`.
+
+## API Endpoints
+
+- `POST /api/register` – Register a new user. Requires `username` and `password` in the body.
+- `POST /api/login` – Login a user. Requires `username` and `password` in the body.
+- `GET /api/posts` – List all posts.
+- `POST /api/posts` – Create a post. Requires `userId`, `title` and `content`.
+- `GET /api/posts/:id` – Get a single post with comments.
+- `POST /api/posts/:id/comments` – Create a comment on a post. Requires `userId` and `content`.
+
+The database will be created automatically in `db.sqlite` when you run the server for the first time.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codex-cool-webboard",
+  "version": "1.0.0",
+  "description": "Simple web board API service",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6",
+    "bcrypt": "^5.1.0",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,65 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const DBSOURCE = path.join(__dirname, '..', 'db.sqlite');
+
+const db = new sqlite3.Database(DBSOURCE, (err) => {
+  if (err) {
+    console.error('Could not connect to database', err);
+  } else {
+    console.log('Connected to SQLite database');
+  }
+});
+
+// create tables if they do not exist
+const init = () => {
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE,
+      password_hash TEXT
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER,
+      title TEXT,
+      content TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(user_id) REFERENCES users(id)
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS comments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      post_id INTEGER,
+      user_id INTEGER,
+      content TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY(post_id) REFERENCES posts(id),
+      FOREIGN KEY(user_id) REFERENCES users(id)
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS tags (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT UNIQUE
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS post_tags (
+      post_id INTEGER,
+      tag_id INTEGER,
+      PRIMARY KEY(post_id, tag_id),
+      FOREIGN KEY(post_id) REFERENCES posts(id),
+      FOREIGN KEY(tag_id) REFERENCES tags(id)
+    )`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS favorites (
+      user_id INTEGER,
+      post_id INTEGER,
+      PRIMARY KEY(user_id, post_id),
+      FOREIGN KEY(user_id) REFERENCES users(id),
+      FOREIGN KEY(post_id) REFERENCES posts(id)
+    )`);
+  });
+};
+
+module.exports = { db, init };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,89 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const bcrypt = require('bcrypt');
+const { db, init } = require('./database');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(bodyParser.json());
+
+init();
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
+  const password_hash = bcrypt.hashSync(password, 10);
+  const stmt = db.prepare('INSERT INTO users(username, password_hash) VALUES (?, ?)');
+  stmt.run([username, password_hash], function(err) {
+    if (err) {
+      return res.status(500).json({ error: 'Could not register user', details: err.message });
+    }
+    res.json({ id: this.lastID, username });
+  });
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'username and password required' });
+  }
+  db.get('SELECT * FROM users WHERE username = ?', [username], (err, row) => {
+    if (err || !row) {
+      return res.status(400).json({ error: 'invalid username or password' });
+    }
+    if (!bcrypt.compareSync(password, row.password_hash)) {
+      return res.status(400).json({ error: 'invalid username or password' });
+    }
+    res.json({ message: 'login successful', userId: row.id });
+  });
+});
+
+app.get('/api/posts', (req, res) => {
+  db.all('SELECT * FROM posts ORDER BY created_at DESC', [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/posts', (req, res) => {
+  const { userId, title, content } = req.body;
+  if (!userId || !title || !content) {
+    return res.status(400).json({ error: 'userId, title and content required' });
+  }
+  const stmt = db.prepare('INSERT INTO posts(user_id, title, content) VALUES (?, ?, ?)');
+  stmt.run([userId, title, content], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ id: this.lastID, userId, title, content });
+  });
+});
+
+app.get('/api/posts/:id', (req, res) => {
+  const postId = req.params.id;
+  db.get('SELECT * FROM posts WHERE id = ?', [postId], (err, row) => {
+    if (err || !row) return res.status(404).json({ error: 'post not found' });
+    db.all('SELECT * FROM comments WHERE post_id = ? ORDER BY created_at', [postId], (cerr, comments) => {
+      if (cerr) return res.status(500).json({ error: cerr.message });
+      res.json({ ...row, comments });
+    });
+  });
+});
+
+app.post('/api/posts/:id/comments', (req, res) => {
+  const postId = req.params.id;
+  const { userId, content } = req.body;
+  if (!userId || !content) {
+    return res.status(400).json({ error: 'userId and content required' });
+  }
+  const stmt = db.prepare('INSERT INTO comments(post_id, user_id, content) VALUES (?, ?, ?)');
+  stmt.run([postId, userId, content], function(err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ id: this.lastID, postId, userId, content });
+  });
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- set up Node.js project with Express, SQLite and bcrypt
- implement database initialization and API endpoints
- document how to run the service

## Testing
- `npm install --silent`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6840d7c8ab348333b3a31220c3b3a19c